### PR TITLE
Feature: streamable structured outputs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,90 @@
+name: 🪲 Bug Report
+description: Report an issue with the Dedalus Python SDK
+labels:
+  - bug
+  - needs triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for submitting a bug report! Your vigilance helps make the Dedalus SDK better for everyone.
+
+        **Please read this first:**
+        - **Have you searched for related issues?** Others may have faced similar issues
+        - **Have you checked the documentation?** Review the [README](../../README.md) and examples
+
+        Make sure you are running the latest version. The bug you are experiencing may already have been fixed.
+
+  - type: input
+    id: version
+    attributes:
+      label: SDK version
+      description: Copy the output of `python -c "import dedalus_labs; print(dedalus_labs.__version__)"`
+      placeholder: "e.g., 0.0.1, 0.0.2.dev5"
+    validations:
+      required: true
+
+  - type: input
+    id: python_version
+    attributes:
+      label: Python version
+      description: Copy the output of `python --version`
+      placeholder: "e.g., Python 3.12.1"
+    validations:
+      required: true
+
+  - type: input
+    id: platform
+    attributes:
+      label: Platform
+      description: |
+        For macOS/Linux: copy the output of `uname -mprs`
+        For Windows: copy the output of `"$([Environment]::OSVersion | ForEach-Object VersionString) $(if ([Environment]::Is64BitOperatingSystem) { "x64" } else { "x86" })"` in PowerShell
+      placeholder: "e.g., Darwin 24.6.0 arm64, Linux 5.15.0 x86_64"
+
+  - type: textarea
+    id: error_type
+    attributes:
+      label: Error type
+      description: What type of error occurred? (if applicable)
+      placeholder: "e.g., APIError, APITimeoutError, BadRequestError, AuthenticationError"
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What issue are you seeing?
+      description: A clear description of the bug. Include full error messages (redact any sensitive data). Provide text instead of screenshots when possible.
+      placeholder: |
+        Describe the issue and include error messages, stack traces, or unexpected behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide a minimal code snippet that reproduces the bug. Ideally a minimal Python script that can be run.
+      placeholder: |
+        ```python
+        from dedalus_labs import Dedalus
+
+        client = Dedalus(api_key="...")
+        # Steps that trigger the bug
+        response = client.chat.completions.create(...)
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: A clear description of what you expected to happen.
+      placeholder: "Describe what should have happened instead."
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+      description: Any other information that might help us investigate?
+      placeholder: "Request IDs, timestamps, API endpoint used, etc."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "anyio>=3.5.0, <5",
     "distro>=1.7.0, <2",
     "sniffio",
-    "jiter>=0.10.0, <1",
+    "jiter<0.10.0",
 ]
 requires-python = ">= 3.8"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "anyio>=3.5.0, <5",
     "distro>=1.7.0, <2",
     "sniffio",
+    "jiter>=0.10.0, <1",
 ]
 requires-python = ">= 3.8"
 classifiers = [

--- a/src/dedalus_labs/__init__.py
+++ b/src/dedalus_labs/__init__.py
@@ -40,6 +40,7 @@ from ._exceptions import (
 from ._base_client import DefaultHttpxClient, DefaultAioHttpClient, DefaultAsyncHttpxClient
 from ._utils._logs import setup_logging as _setup_logging
 from .lib.runner import DedalusRunner
+from .lib._bug_report import generate_bug_report_url, get_bug_report_url_from_error
 
 __all__ = [
     "types",
@@ -85,6 +86,8 @@ __all__ = [
     "DefaultAsyncHttpxClient",
     "DefaultAioHttpClient",
     "DedalusRunner",
+    "generate_bug_report_url",
+    "get_bug_report_url_from_error",
 ]
 
 if not _t.TYPE_CHECKING:

--- a/src/dedalus_labs/_compat.py
+++ b/src/dedalus_labs/_compat.py
@@ -143,7 +143,7 @@ def model_dump(
     if (not PYDANTIC_V1) or hasattr(model, "model_dump"):
         return model.model_dump(
             mode=mode,
-            by_alias=True,  # Always use aliases for API serialization
+            by_alias=True,
             exclude=exclude,
             exclude_unset=exclude_unset,
             exclude_defaults=exclude_defaults,
@@ -153,7 +153,7 @@ def model_dump(
     return cast(
         "dict[str, Any]",
         model.dict(  # pyright: ignore[reportDeprecated, reportUnnecessaryCast]
-            by_alias=True,  # Always use aliases for API serialization
+            by_alias=True,
             exclude=exclude,
             exclude_unset=exclude_unset,
             exclude_defaults=exclude_defaults,
@@ -174,11 +174,11 @@ def model_parse_json(model: type[_ModelT], data: str | bytes) -> _ModelT:
     return model.model_validate_json(data)
 
 
-def model_json_schema(model: type[pydantic.BaseModel], by_alias: bool = True) -> dict[str, Any]:
+def model_json_schema(model: type[_ModelT]) -> dict[str, Any]:
     """Get JSON schema from Pydantic model."""
     if PYDANTIC_V1:
-        return model.schema(by_alias=by_alias)  # pyright: ignore[reportDeprecated]
-    return model.model_json_schema(by_alias=by_alias)
+        return model.schema()  # pyright: ignore[reportDeprecated]
+    return model.model_json_schema()
 
 
 # generic models

--- a/src/dedalus_labs/_compat.py
+++ b/src/dedalus_labs/_compat.py
@@ -143,6 +143,7 @@ def model_dump(
     if (not PYDANTIC_V1) or hasattr(model, "model_dump"):
         return model.model_dump(
             mode=mode,
+            by_alias=True,  # Always use aliases for API serialization
             exclude=exclude,
             exclude_unset=exclude_unset,
             exclude_defaults=exclude_defaults,
@@ -152,6 +153,7 @@ def model_dump(
     return cast(
         "dict[str, Any]",
         model.dict(  # pyright: ignore[reportDeprecated, reportUnnecessaryCast]
+            by_alias=True,  # Always use aliases for API serialization
             exclude=exclude,
             exclude_unset=exclude_unset,
             exclude_defaults=exclude_defaults,
@@ -172,11 +174,11 @@ def model_parse_json(model: type[_ModelT], data: str | bytes) -> _ModelT:
     return model.model_validate_json(data)
 
 
-def model_json_schema(model: type[pydantic.BaseModel]) -> dict[str, Any]:
+def model_json_schema(model: type[pydantic.BaseModel], by_alias: bool = True) -> dict[str, Any]:
     """Get JSON schema from Pydantic model."""
     if PYDANTIC_V1:
-        return model.schema()  # pyright: ignore[reportDeprecated]
-    return model.model_json_schema()
+        return model.schema(by_alias=by_alias)  # pyright: ignore[reportDeprecated]
+    return model.model_json_schema(by_alias=by_alias)
 
 
 # generic models

--- a/src/dedalus_labs/lib/_bug_report.py
+++ b/src/dedalus_labs/lib/_bug_report.py
@@ -1,0 +1,150 @@
+# ==============================================================================
+#                  © 2025 Dedalus Labs, Inc. and affiliates
+#                            Licensed under MIT
+#           github.com/dedalus-labs/dedalus-sdk-python/LICENSE
+# ==============================================================================
+
+"""Bug report URL generation for SDK users."""
+
+from __future__ import annotations
+
+import platform
+import sys
+from typing import TYPE_CHECKING
+from urllib.parse import urlencode
+
+if TYPE_CHECKING:
+    from dedalus_labs._exceptions import APIError
+
+
+__all__ = ["generate_bug_report_url", "get_bug_report_url_from_error"]
+
+
+BASE_ISSUE_URL = "https://github.com/dedalus-labs/dedalus-sdk-python/issues/new"
+
+
+def generate_bug_report_url(
+    *,
+    version: str | None = None,
+    error_type: str | None = None,
+    error_message: str | None = None,
+    endpoint: str | None = None,
+    method: str | None = None,
+    request_id: str | None = None,
+    environment: str | None = None,
+    template: str = "bug-report.yml",
+) -> str:
+    """
+    Generate pre-filled GitHub issue URL for SDK bug reports.
+
+    Auto-populates system context (Python version, platform) and allows
+    caller to provide error details. URL parameters match field IDs in
+    .github/ISSUE_TEMPLATE/bug-report.yml.
+
+    Args:
+        version: SDK version string
+        error_type: Exception class name
+        error_message: Brief error description
+        endpoint: API endpoint path (e.g., /v1/chat/completions)
+        method: HTTP method (GET, POST, etc.)
+        request_id: Request ID from API response headers for log correlation
+        environment: dev/staging/prod
+        template: GitHub issue template filename
+
+    Returns:
+        GitHub issue URL with pre-filled fields
+
+    Example:
+        >>> url = generate_bug_report_url(
+        ...     version="0.0.1",
+        ...     error_type="APIError",
+        ...     error_message="Connection timeout",
+        ...     endpoint="/v1/chat/completions",
+        ...     method="POST",
+        ... )
+    """
+    params = {"template": template, "component": "Python SDK"}
+
+    if version:
+        params["version"] = version
+    if error_type:
+        params["error_type"] = error_type
+
+    # Auto-populate system info
+    params["python_version"] = f"Python {sys.version.split()[0]}"
+    params["platform"] = _get_platform_info()
+
+    if environment:
+        params["environment"] = environment
+
+    # Construct notes field with request context
+    notes_parts = []
+    if request_id:
+        notes_parts.append(f"Request ID: {request_id}")
+    if endpoint:
+        notes_parts.append(f"Endpoint: {method or 'POST'} {endpoint}")
+    if notes_parts:
+        params["notes"] = "\n".join(notes_parts)
+
+    # Error message goes in actual field
+    if error_message:
+        params["actual"] = error_message
+
+    return f"{BASE_ISSUE_URL}?{urlencode(params)}"
+
+
+def get_bug_report_url_from_error(error: APIError, *, request_id: str | None = None) -> str:
+    """
+    Generate bug report URL from SDK exception instance.
+
+    Extracts error context automatically from the exception object,
+    including error type, message, request details (endpoint, method),
+    and optionally request ID from response headers.
+
+    Args:
+        error: SDK exception instance (APIError or subclass)
+        request_id: Optional request ID override (auto-extracted from response if available)
+
+    Returns:
+        GitHub issue URL with error context pre-filled
+
+    Example:
+        >>> try:
+        ...     client.chat.completions.create(...)
+        ... except dedalus_labs.APIError as e:
+        ...     url = get_bug_report_url_from_error(e)
+        ...     print(f"Report bug: {url}")
+    """
+    from dedalus_labs import __version__
+
+    error_type = type(error).__name__
+    error_message = str(error)
+
+    # Extract status code if available
+    if hasattr(error, "status_code"):
+        error_message = f"[{error.status_code}] {error_message}"
+
+    # Extract request details
+    endpoint = None
+    method = None
+    if hasattr(error, "request"):
+        endpoint = str(error.request.url.path) if error.request.url else None
+        method = error.request.method
+
+    # Extract request_id from response headers if not provided
+    if request_id is None and hasattr(error, "response"):
+        request_id = error.response.headers.get("x-request-id")
+
+    return generate_bug_report_url(
+        version=__version__,
+        error_type=error_type,
+        error_message=error_message,
+        endpoint=endpoint,
+        method=method,
+        request_id=request_id,
+    )
+
+
+def _get_platform_info() -> str:
+    """Format platform info: 'Darwin 24.6.0 arm64' or 'Linux 5.15.0 x86_64'."""
+    return f"{platform.system()} {platform.release()} {platform.machine()}"

--- a/src/dedalus_labs/lib/_parsing/__init__.py
+++ b/src/dedalus_labs/lib/_parsing/__init__.py
@@ -2,14 +2,24 @@ from __future__ import annotations
 
 from ._completions import (
     ResponseFormatT as ResponseFormatT,
+    get_input_tool_by_name as get_input_tool_by_name,
+    has_parseable_input as has_parseable_input,
+    maybe_parse_content as maybe_parse_content,
     parse_chat_completion as parse_chat_completion,
+    parse_function_tool_arguments as parse_function_tool_arguments,
+    solve_response_format_t as solve_response_format_t,
     type_to_response_format_param as type_to_response_format_param,
     validate_input_tools as validate_input_tools,
 )
 
 __all__ = [
     "ResponseFormatT",
+    "get_input_tool_by_name",
+    "has_parseable_input",
+    "maybe_parse_content",
     "parse_chat_completion",
+    "parse_function_tool_arguments",
+    "solve_response_format_t",
     "type_to_response_format_param",
     "validate_input_tools",
 ]

--- a/src/dedalus_labs/lib/_parsing/_completions.py
+++ b/src/dedalus_labs/lib/_parsing/_completions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from typing import TYPE_CHECKING, Any, Dict, Iterable, cast
-from typing_extensions import TypeVar, TypeGuard
+from typing_extensions import TypeGuard, TypeVar
 
 import pydantic
 
@@ -11,24 +11,46 @@ from ..._types import Omit, omit
 from ..._utils import is_dict, is_given
 from ..._compat import PYDANTIC_V1, model_parse_json
 from ..._models import construct_type_unchecked
-from .._pydantic import is_basemodel_type, to_strict_json_schema, is_dataclass_like_type
+from .._pydantic import is_basemodel_type, is_dataclass_like_type, to_strict_json_schema
 
 if TYPE_CHECKING:
-    from ...types.chat.completion_create_params import ResponseFormat as ResponseFormatParam
-    from ...types.chat.completion import ChoiceMessageToolCallChatCompletionMessageToolCallFunction as Function
+    # Import proper ResponseFormat type from server schemas
+    # At runtime this is just a dict, but for type checking we want the union
+    ResponseFormatParam = Dict[str, Any]
+else:
+    ResponseFormatParam = Dict[str, Any]
 
-ResponseFormatT = TypeVar("ResponseFormatT")
+if TYPE_CHECKING:
+    from ...types.chat.completion import (
+        Completion,
+        Choice,
+        ChoiceMessage,
+        ChoiceMessageToolCallChatCompletionMessageToolCallFunction as Function,
+    )
+    from ...types.chat.parsed_chat_completion import (
+        ParsedChoice,
+        ParsedChatCompletion,
+        ParsedChatCompletionMessage,
+    )
+    from ...types.chat.parsed_function_tool_call import ParsedFunctionToolCall
+
+
+ResponseFormatT = TypeVar(
+    "ResponseFormatT",
+    default=None,
+)
+_default_response_format: None = None
 
 
 def type_to_response_format_param(
     response_format: type | ResponseFormatParam | Omit,
 ) -> ResponseFormatParam | Omit:
-    """Convert Pydantic model to API response_format parameter."""
+    """Convert a response_format convenience value into the wire schema."""
     if not is_given(response_format):
         return omit
 
     if is_dict(response_format):
-        return response_format
+        return cast(ResponseFormatParam, response_format)
 
     response_format = cast(type, response_format)
 
@@ -39,7 +61,7 @@ def type_to_response_format_param(
         name = response_format.__name__
         json_schema_type = pydantic.TypeAdapter(response_format)
     else:
-        raise TypeError(f"Unsupported response_format type - {response_format}")
+        raise TypeError(f"Unsupported response_format type: {response_format}")
 
     return {
         "type": "json_schema",
@@ -52,18 +74,18 @@ def type_to_response_format_param(
 
 
 def validate_input_tools(tools: Iterable[Dict[str, Any]] | Omit = omit) -> Iterable[Dict[str, Any]] | Omit:
-    """Validate tools for strict parsing support."""
+    """Ensure all provided tools can participate in automatic parsing."""
     if not is_given(tools):
         return omit
 
     for tool in tools:
         if tool.get("type") != "function":
-            raise ValueError(f"Only function tools support auto-parsing; got {tool.get('type')}")
+            raise ValueError(f"Only function tools support auto-parsing; received '{tool.get('type')}'.")
 
         strict = tool.get("function", {}).get("strict")
         if strict is not True:
-            name = tool.get("function", {}).get("name", "unknown")
-            raise ValueError(f"Tool '{name}' is not strict. Only strict function tools can be auto-parsed")
+            name = tool.get("function", {}).get("name", "unknown_function")
+            raise ValueError(f"Tool '{name}' is not strict. Only strict function tools can be auto-parsed.")
 
     return cast(Iterable[Dict[str, Any]], tools)
 
@@ -71,37 +93,36 @@ def validate_input_tools(tools: Iterable[Dict[str, Any]] | Omit = omit) -> Itera
 def parse_chat_completion(
     *,
     response_format: type[ResponseFormatT] | ResponseFormatParam | Omit,
-    chat_completion: Any,
+    chat_completion: Completion | ParsedChatCompletion[object],
     input_tools: Iterable[Dict[str, Any]] | Omit = omit,
-) -> Any:
-    """Parse completion: response content and tool call arguments into Pydantic models."""
+) -> ParsedChatCompletion[ResponseFormatT]:
+    """Parse a completion's content & tool calls into structured objects."""
     from ...types.chat.parsed_chat_completion import (
-        ParsedChatCompletion,
         ParsedChoice,
-        ParsedChatCompletionMessage,
+        ParsedChatCompletion,
     )
-    from ...types.chat.parsed_function_tool_call import ParsedFunctionToolCall, ParsedFunction
+    from ...types.chat.parsed_function_tool_call import ParsedFunctionToolCall
 
     tool_list = list(input_tools) if is_given(input_tools) else []
 
-    choices = []
+    parsed_choices = []
     for choice in chat_completion.choices:
         message = choice.message
 
-        # Parse tool calls if present
         tool_calls = []
-        if hasattr(message, "tool_calls") and message.tool_calls:
-            for tool_call in message.tool_calls:
-                if tool_call.type == "function":
-                    parsed_args = _parse_function_tool_arguments(
-                        input_tools=tool_list, function=tool_call.function
+        if getattr(message, "tool_calls", None):
+            for tool_call in message.tool_calls:  # type: ignore[attr-defined]
+                if getattr(tool_call, "type", None) == "function":
+                    parsed_args = parse_function_tool_arguments(
+                        input_tools=tool_list,
+                        function=tool_call.function,  # type: ignore[attr-defined]
                     )
                     tool_calls.append(
                         construct_type_unchecked(
                             value={
                                 **tool_call.to_dict(),
                                 "function": {
-                                    **tool_call.function.to_dict(),
+                                    **tool_call.function.to_dict(),  # type: ignore[attr-defined]
                                     "parsed_arguments": parsed_args,
                                 },
                             },
@@ -111,56 +132,121 @@ def parse_chat_completion(
                 else:
                     tool_calls.append(tool_call)
 
-        # Parse response content
-        parsed_content = None
-        if is_given(response_format) and not is_dict(response_format):
-            if message.content and not getattr(message, "refusal", None):
-                parsed_content = _parse_content(response_format, message.content)
-
-        choices.append(
+        parsed_choices.append(
             construct_type_unchecked(
-                type_=cast(Any, ParsedChoice),
+                type_=cast(Any, ParsedChoice)[solve_response_format_t(response_format)],
                 value={
                     **choice.to_dict(),
                     "message": {
                         **message.to_dict(),
-                        "parsed": parsed_content,
+                        "parsed": maybe_parse_content(response_format=response_format, message=message),
                         "tool_calls": tool_calls if tool_calls else None,
                     },
                 },
             )
         )
 
-    return construct_type_unchecked(
-        type_=cast(Any, ParsedChatCompletion),
-        value={
-            **chat_completion.to_dict(),
-            "choices": choices,
-        },
+    return cast(
+        ParsedChatCompletion[ResponseFormatT],
+        construct_type_unchecked(
+            type_=cast(Any, ParsedChatCompletion)[solve_response_format_t(response_format)],
+            value={
+                **chat_completion.to_dict(),
+                "choices": parsed_choices,
+            },
+        ),
     )
 
 
-def _parse_function_tool_arguments(*, input_tools: list[Dict[str, Any]], function: Function) -> object | None:
-    """Parse tool call arguments using Pydantic if tool schema is available."""
-    input_tool = next(
-        (t for t in input_tools if t.get("type") == "function" and t.get("function", {}).get("name") == function.name),
+def maybe_parse_content(
+    *,
+    response_format: type[ResponseFormatT] | ResponseFormatParam | Omit,
+    message: ChoiceMessage | ParsedChatCompletionMessage[object],
+) -> ResponseFormatT | None:
+    if has_rich_response_format(response_format) and getattr(message, "content", None) and not getattr(
+        message, "refusal", None
+    ):
+        return _parse_content(response_format, cast(str, message.content))
+
+    return None
+
+
+def has_parseable_input(
+    *,
+    response_format: type | ResponseFormatParam | Omit,
+    input_tools: Iterable[Dict[str, Any]] | Omit = omit,
+) -> bool:
+    if has_rich_response_format(response_format):
+        return True
+
+    for input_tool in input_tools or []:
+        if is_parseable_tool(input_tool):
+            return True
+
+    return False
+
+
+def solve_response_format_t(
+    response_format: type[ResponseFormatT] | ResponseFormatParam | Omit,
+) -> type[ResponseFormatT]:
+    if has_rich_response_format(response_format):
+        return cast("type[ResponseFormatT]", response_format)
+
+    return cast("type[ResponseFormatT]", _default_response_format)
+
+
+def get_input_tool_by_name(
+    *,
+    input_tools: list[Dict[str, Any]],
+    name: str,
+) -> Dict[str, Any] | None:
+    return next(
+        (tool for tool in input_tools if tool.get("type") == "function" and tool.get("function", {}).get("name") == name),
         None,
     )
+
+
+def parse_function_tool_arguments(
+    *,
+    input_tools: list[Dict[str, Any]],
+    function: "Function",
+) -> object | None:
+    input_tool = get_input_tool_by_name(input_tools=input_tools, name=function.name)
     if not input_tool:
         return None
 
-    input_fn = input_tool.get("function")
-    if isinstance(input_fn, PydanticFunctionTool):
-        return model_parse_json(input_fn.model, function.arguments)
+    definition = input_tool.get("function")
+    if isinstance(definition, PydanticFunctionTool):
+        return model_parse_json(definition.model, function.arguments)
 
-    if input_fn and input_fn.get("strict"):
+    if isinstance(definition, dict) and definition.get("strict") and definition.get("parameters"):
         return json.loads(function.arguments)
 
     return None
 
 
+def has_rich_response_format(
+    response_format: type[ResponseFormatT] | ResponseFormatParam | Omit,
+) -> TypeGuard[type[ResponseFormatT]]:
+    return is_given(response_format) and not is_response_format_param(response_format)
+
+
+def is_response_format_param(response_format: object) -> TypeGuard[ResponseFormatParam]:
+    return is_dict(response_format)
+
+
+def is_parseable_tool(tool: Dict[str, Any]) -> bool:
+    if tool.get("type") != "function":
+        return False
+
+    definition = tool.get("function")
+    if isinstance(definition, PydanticFunctionTool):
+        return True
+
+    return bool(isinstance(definition, dict) and definition.get("strict"))
+
+
 def _parse_content(response_format: type[ResponseFormatT], content: str) -> ResponseFormatT:
-    """Deserialize JSON string into typed Pydantic model."""
     if is_basemodel_type(response_format):
         return cast(ResponseFormatT, model_parse_json(response_format, content))
 
@@ -170,3 +256,16 @@ def _parse_content(response_format: type[ResponseFormatT], content: str) -> Resp
         return pydantic.TypeAdapter(response_format).validate_json(content)
 
     raise TypeError(f"Unable to automatically parse response format type {response_format}")
+
+
+__all__ = [
+    "ResponseFormatT",
+    "get_input_tool_by_name",
+    "has_parseable_input",
+    "maybe_parse_content",
+    "parse_chat_completion",
+    "parse_function_tool_arguments",
+    "solve_response_format_t",
+    "type_to_response_format_param",
+    "validate_input_tools",
+]

--- a/src/dedalus_labs/lib/runner/types/tools.py
+++ b/src/dedalus_labs/lib/runner/types/tools.py
@@ -6,7 +6,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Union, Callable, Protocol, TypeAlias
+from typing import Any, Dict, List, Union, Callable, Protocol
+from typing_extensions import TypeAlias
 
 __all__ = [
     "Tool",

--- a/src/dedalus_labs/lib/streaming/__init__.py
+++ b/src/dedalus_labs/lib/streaming/__init__.py
@@ -1,0 +1,17 @@
+from ._deltas import accumulate_delta as accumulate_delta
+from .chat import (
+    ChatCompletionStream as ChatCompletionStream,
+    AsyncChatCompletionStream as AsyncChatCompletionStream,
+    ChatCompletionStreamManager as ChatCompletionStreamManager,
+    AsyncChatCompletionStreamManager as AsyncChatCompletionStreamManager,
+    ChatCompletionStreamState as ChatCompletionStreamState,
+)
+
+__all__ = [
+    "accumulate_delta",
+    "ChatCompletionStream",
+    "AsyncChatCompletionStream",
+    "ChatCompletionStreamManager",
+    "AsyncChatCompletionStreamManager",
+    "ChatCompletionStreamState",
+]

--- a/src/dedalus_labs/lib/streaming/_deltas.py
+++ b/src/dedalus_labs/lib/streaming/_deltas.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from ..._utils import is_dict, is_list
+
+
+def accumulate_delta(acc: dict[object, object], delta: dict[object, object]) -> dict[object, object]:
+    """Merge a chunk delta into the running accumulator."""
+    for key, delta_value in delta.items():
+        if key not in acc:
+            acc[key] = delta_value
+            continue
+
+        acc_value = acc[key]
+        if acc_value is None:
+            acc[key] = delta_value
+            continue
+
+        if key in {"index", "type"}:
+            acc[key] = delta_value
+            continue
+
+        if isinstance(acc_value, str) and isinstance(delta_value, str):
+            acc_value += delta_value
+        elif isinstance(acc_value, (int, float)) and isinstance(delta_value, (int, float)):
+            acc_value += delta_value
+        elif is_dict(acc_value) and is_dict(delta_value):
+            acc_value = accumulate_delta(acc_value, delta_value)
+        elif is_list(acc_value) and is_list(delta_value):
+            if all(isinstance(entry, (str, int, float)) for entry in acc_value):
+                acc_value.extend(delta_value)
+                acc[key] = acc_value
+                continue
+
+            for delta_entry in delta_value:
+                if not is_dict(delta_entry):
+                    raise TypeError(f"Expected chunk delta entry to be a dict, received {delta_entry!r}")
+
+                index = delta_entry.get("index")
+                if not isinstance(index, int):
+                    raise TypeError(f"Chunk delta entry missing integer index: {delta_entry!r}")
+
+                if index >= len(acc_value):
+                    acc_value.insert(index, delta_entry)
+                    continue
+
+                acc_entry = acc_value[index]
+                if not is_dict(acc_entry):
+                    raise TypeError("Cannot merge non-dict list entries in streaming delta")
+
+                acc_value[index] = accumulate_delta(acc_entry, delta_entry)
+
+        acc[key] = acc_value
+
+    return acc
+
+
+__all__ = ["accumulate_delta"]

--- a/src/dedalus_labs/lib/streaming/chat/__init__.py
+++ b/src/dedalus_labs/lib/streaming/chat/__init__.py
@@ -1,0 +1,49 @@
+from ._events import (
+    ChunkEvent as ChunkEvent,
+    ContentDoneEvent as ContentDoneEvent,
+    ContentDeltaEvent as ContentDeltaEvent,
+    RefusalDoneEvent as RefusalDoneEvent,
+    RefusalDeltaEvent as RefusalDeltaEvent,
+    FunctionToolCallArgumentsDoneEvent as FunctionToolCallArgumentsDoneEvent,
+    FunctionToolCallArgumentsDeltaEvent as FunctionToolCallArgumentsDeltaEvent,
+    LogprobsContentDoneEvent as LogprobsContentDoneEvent,
+    LogprobsContentDeltaEvent as LogprobsContentDeltaEvent,
+    LogprobsRefusalDoneEvent as LogprobsRefusalDoneEvent,
+    LogprobsRefusalDeltaEvent as LogprobsRefusalDeltaEvent,
+    ChatCompletionStreamEvent as ChatCompletionStreamEvent,
+)
+from ._types import (
+    ParsedChoiceSnapshot as ParsedChoiceSnapshot,
+    ParsedChatCompletionSnapshot as ParsedChatCompletionSnapshot,
+    ParsedChatCompletionMessageSnapshot as ParsedChatCompletionMessageSnapshot,
+)
+from ._completions import (
+    ChatCompletionStream as ChatCompletionStream,
+    AsyncChatCompletionStream as AsyncChatCompletionStream,
+    ChatCompletionStreamManager as ChatCompletionStreamManager,
+    AsyncChatCompletionStreamManager as AsyncChatCompletionStreamManager,
+    ChatCompletionStreamState as ChatCompletionStreamState,
+)
+
+__all__ = [
+    "AsyncChatCompletionStream",
+    "AsyncChatCompletionStreamManager",
+    "ChatCompletionStream",
+    "ChatCompletionStreamEvent",
+    "ChatCompletionStreamManager",
+    "ChatCompletionStreamState",
+    "ChunkEvent",
+    "ContentDeltaEvent",
+    "ContentDoneEvent",
+    "FunctionToolCallArgumentsDeltaEvent",
+    "FunctionToolCallArgumentsDoneEvent",
+    "LogprobsContentDeltaEvent",
+    "LogprobsContentDoneEvent",
+    "LogprobsRefusalDeltaEvent",
+    "LogprobsRefusalDoneEvent",
+    "ParsedChatCompletionMessageSnapshot",
+    "ParsedChatCompletionSnapshot",
+    "ParsedChoiceSnapshot",
+    "RefusalDeltaEvent",
+    "RefusalDoneEvent",
+]

--- a/src/dedalus_labs/lib/streaming/chat/_completions.py
+++ b/src/dedalus_labs/lib/streaming/chat/_completions.py
@@ -1,0 +1,776 @@
+from __future__ import annotations
+
+import inspect
+from types import TracebackType
+from typing import TYPE_CHECKING, Any, Dict, Generic, Callable, Iterable, Awaitable, AsyncIterator, cast
+from typing_extensions import Self, Iterator, assert_never
+
+from jiter import from_json
+
+from ._types import ParsedChoiceSnapshot, ParsedChatCompletionSnapshot, ParsedChatCompletionMessageSnapshot
+from ._events import (
+    ChunkEvent,
+    ContentDoneEvent,
+    RefusalDoneEvent,
+    ContentDeltaEvent,
+    RefusalDeltaEvent,
+    LogprobsContentDoneEvent,
+    LogprobsRefusalDoneEvent,
+    ChatCompletionStreamEvent,
+    LogprobsContentDeltaEvent,
+    LogprobsRefusalDeltaEvent,
+    FunctionToolCallArgumentsDoneEvent,
+    FunctionToolCallArgumentsDeltaEvent,
+)
+from .._deltas import accumulate_delta
+from ...._types import Omit, IncEx, omit
+from ...._utils import is_given, consume_sync_iterator, consume_async_iterator
+from ...._compat import model_dump
+from ...._models import build, construct_type
+from ..._parsing import (
+    ResponseFormatT,
+    has_parseable_input,
+    maybe_parse_content,
+    parse_chat_completion,
+    get_input_tool_by_name,
+    solve_response_format_t,
+    parse_function_tool_arguments,
+)
+from ...._streaming import Stream, AsyncStream
+from ....types.chat.stream_chunk import StreamChunk
+from ....types.chat.parsed_chat_completion import ParsedChatCompletion
+from ....types.chat.completion import ChoiceLogprobs
+from ....types.chat.stream_chunk import Choice as ChoiceChunk
+
+
+InputTool = Dict[str, Any]
+ResponseFormatParam = Dict[str, Any]
+
+
+class LengthFinishReasonError(RuntimeError):
+    """Raised when streaming stops due to max tokens before parsing completes."""
+
+
+class ContentFilterFinishReasonError(RuntimeError):
+    """Raised when streaming output is blocked by a content filter."""
+
+
+class ChatCompletionStream(Generic[ResponseFormatT]):
+    """Wrapper over the Chat Completions streaming API that adds helpful
+    events such as `content.done`, supports automatically parsing
+    responses & tool calls and accumulates a `ChatCompletion` object
+    from each individual chunk.
+
+    https://platform.openai.com/docs/api-reference/streaming
+    """
+
+    def __init__(
+        self,
+        *,
+        raw_stream: Stream[StreamChunk],
+        response_format: type[ResponseFormatT] | ResponseFormatParam | Omit,
+        input_tools: Iterable[InputTool] | Omit,
+    ) -> None:
+        self._raw_stream = raw_stream
+        self._response = raw_stream.response
+        self._iterator = self.__stream__()
+        self._state = ChatCompletionStreamState(response_format=response_format, input_tools=input_tools)
+
+    def __next__(self) -> ChatCompletionStreamEvent[ResponseFormatT]:
+        return self._iterator.__next__()
+
+    def __iter__(self) -> Iterator[ChatCompletionStreamEvent[ResponseFormatT]]:
+        for item in self._iterator:
+            yield item
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """
+        Close the response and release the connection.
+
+        Automatically called if the response body is read to completion.
+        """
+        self._response.close()
+
+    def get_final_completion(self) -> ParsedChatCompletion[ResponseFormatT]:
+        """Waits until the stream has been read to completion and returns
+        the accumulated `ParsedChatCompletion` object.
+
+        If you passed a class type to `.stream()`, the `completion.choices[0].message.parsed`
+        property will be the content deserialised into that class, if there was any content returned
+        by the API.
+        """
+        self.until_done()
+        return self._state.get_final_completion()
+
+    def until_done(self) -> Self:
+        """Blocks until the stream has been consumed."""
+        consume_sync_iterator(self)
+        return self
+
+    @property
+    def current_completion_snapshot(self) -> ParsedChatCompletionSnapshot:
+        return self._state.current_completion_snapshot
+
+    def __stream__(self) -> Iterator[ChatCompletionStreamEvent[ResponseFormatT]]:
+        for sse_event in self._raw_stream:
+            if not _is_valid_stream_chunk(sse_event):
+                continue
+            events_to_fire = self._state.handle_chunk(sse_event)
+            for event in events_to_fire:
+                yield event
+
+
+class ChatCompletionStreamManager(Generic[ResponseFormatT]):
+    """Context manager over a `ChatCompletionStream` that is returned by `.stream()`.
+
+    This context manager ensures the response cannot be leaked if you don't read
+    the stream to completion.
+
+    Usage:
+    ```py
+    with client.chat.completions.stream(...) as stream:
+        for event in stream:
+            ...
+    ```
+    """
+
+    def __init__(
+        self,
+        api_request: Callable[[], Stream[StreamChunk]],
+        *,
+        response_format: type[ResponseFormatT] | ResponseFormatParam | Omit,
+        input_tools: Iterable[InputTool] | Omit,
+    ) -> None:
+        self.__stream: ChatCompletionStream[ResponseFormatT] | None = None
+        self.__api_request = api_request
+        self.__response_format = response_format
+        self.__input_tools = input_tools
+
+    def __enter__(self) -> ChatCompletionStream[ResponseFormatT]:
+        raw_stream = self.__api_request()
+
+        self.__stream = ChatCompletionStream(
+            raw_stream=raw_stream,
+            response_format=self.__response_format,
+            input_tools=self.__input_tools,
+        )
+
+        return self.__stream
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        if self.__stream is not None:
+            self.__stream.close()
+
+
+class AsyncChatCompletionStream(Generic[ResponseFormatT]):
+    """Wrapper over the Chat Completions streaming API that adds helpful
+    events such as `content.done`, supports automatically parsing
+    responses & tool calls and accumulates a `ChatCompletion` object
+    from each individual chunk.
+
+    https://platform.openai.com/docs/api-reference/streaming
+    """
+
+    def __init__(
+        self,
+        *,
+        raw_stream: AsyncStream[StreamChunk],
+        response_format: type[ResponseFormatT] | ResponseFormatParam | Omit,
+        input_tools: Iterable[InputTool] | Omit,
+    ) -> None:
+        self._raw_stream = raw_stream
+        self._response = raw_stream.response
+        self._iterator = self.__stream__()
+        self._state = ChatCompletionStreamState(response_format=response_format, input_tools=input_tools)
+
+    async def __anext__(self) -> ChatCompletionStreamEvent[ResponseFormatT]:
+        return await self._iterator.__anext__()
+
+    async def __aiter__(self) -> AsyncIterator[ChatCompletionStreamEvent[ResponseFormatT]]:
+        async for item in self._iterator:
+            yield item
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        """
+        Close the response and release the connection.
+
+        Automatically called if the response body is read to completion.
+        """
+        await self._response.aclose()
+
+    async def get_final_completion(self) -> ParsedChatCompletion[ResponseFormatT]:
+        """Waits until the stream has been read to completion and returns
+        the accumulated `ParsedChatCompletion` object.
+
+        If you passed a class type to `.stream()`, the `completion.choices[0].message.parsed`
+        property will be the content deserialised into that class, if there was any content returned
+        by the API.
+        """
+        await self.until_done()
+        return self._state.get_final_completion()
+
+    async def until_done(self) -> Self:
+        """Blocks until the stream has been consumed."""
+        await consume_async_iterator(self)
+        return self
+
+    @property
+    def current_completion_snapshot(self) -> ParsedChatCompletionSnapshot:
+        return self._state.current_completion_snapshot
+
+    async def __stream__(self) -> AsyncIterator[ChatCompletionStreamEvent[ResponseFormatT]]:
+        async for sse_event in self._raw_stream:
+            if not _is_valid_stream_chunk(sse_event):
+                continue
+            events_to_fire = self._state.handle_chunk(sse_event)
+            for event in events_to_fire:
+                yield event
+
+
+class AsyncChatCompletionStreamManager(Generic[ResponseFormatT]):
+    """Context manager over a `AsyncChatCompletionStream` that is returned by `.stream()`.
+
+    This context manager ensures the response cannot be leaked if you don't read
+    the stream to completion.
+
+    Usage:
+    ```py
+    async with client.chat.completions.stream(...) as stream:
+        for event in stream:
+            ...
+    ```
+    """
+
+    def __init__(
+        self,
+        api_request: Awaitable[AsyncStream[StreamChunk]],
+        *,
+        response_format: type[ResponseFormatT] | ResponseFormatParam | Omit,
+        input_tools: Iterable[InputTool] | Omit,
+    ) -> None:
+        self.__stream: AsyncChatCompletionStream[ResponseFormatT] | None = None
+        self.__api_request = api_request
+        self.__response_format = response_format
+        self.__input_tools = input_tools
+
+    async def __aenter__(self) -> AsyncChatCompletionStream[ResponseFormatT]:
+        raw_stream = await self.__api_request
+
+        self.__stream = AsyncChatCompletionStream(
+            raw_stream=raw_stream,
+            response_format=self.__response_format,
+            input_tools=self.__input_tools,
+        )
+
+        return self.__stream
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        if self.__stream is not None:
+            await self.__stream.close()
+
+
+class ChatCompletionStreamState(Generic[ResponseFormatT]):
+    """Helper class for manually accumulating streaming chunks into a final completion.
+
+    This is useful in cases where you can't always use the `.stream()` method, e.g.
+
+    from openai.lib.streaming.chat import ChatCompletionStreamState
+
+    state = ChatCompletionStreamState()
+
+    stream = client.chat.completions.create(..., stream=True)
+    for chunk in response:
+        state.handle_chunk(chunk)
+
+        # can also access the accumulated `ChatCompletion` mid-stream
+        state.current_completion_snapshot
+
+    print(state.get_final_completion())
+    """
+
+    def __init__(
+        self,
+        *,
+        input_tools: Iterable[InputTool] | Omit = omit,
+        response_format: type[ResponseFormatT] | ResponseFormatParam | Omit = omit,
+    ) -> None:
+        self.__current_completion_snapshot: ParsedChatCompletionSnapshot | None = None
+        self.__choice_event_states: list[ChoiceEventState] = []
+
+        self._input_tools = [tool for tool in input_tools] if is_given(input_tools) else []
+        self._response_format = response_format
+        self._rich_response_format: type | Omit = response_format if inspect.isclass(response_format) else omit
+
+    def get_final_completion(self) -> ParsedChatCompletion[ResponseFormatT]:
+        """Parse the final completion object.
+
+        Note this does not provide any guarantees that the stream has actually finished, you must
+        only call this method when the stream is finished.
+        """
+        return parse_chat_completion(
+            chat_completion=self.current_completion_snapshot,
+            response_format=self._rich_response_format,
+            input_tools=self._input_tools,
+        )
+
+    @property
+    def current_completion_snapshot(self) -> ParsedChatCompletionSnapshot:
+        assert self.__current_completion_snapshot is not None
+        return self.__current_completion_snapshot
+
+    def handle_chunk(self, chunk: StreamChunk) -> Iterable[ChatCompletionStreamEvent[ResponseFormatT]]:
+        """Accumulate a new chunk into the snapshot and returns an iterable of events to yield."""
+        self.__current_completion_snapshot = self._accumulate_chunk(chunk)
+
+        return self._build_events(
+            chunk=chunk,
+            completion_snapshot=self.__current_completion_snapshot,
+        )
+
+    def _get_choice_state(self, choice: ChoiceChunk) -> ChoiceEventState:
+        try:
+            return self.__choice_event_states[choice.index]
+        except IndexError:
+            choice_state = ChoiceEventState(input_tools=self._input_tools)
+            self.__choice_event_states.append(choice_state)
+            return choice_state
+
+    def _accumulate_chunk(self, chunk: StreamChunk) -> ParsedChatCompletionSnapshot:
+        completion_snapshot = self.__current_completion_snapshot
+
+        if completion_snapshot is None:
+            return _convert_initial_chunk_into_snapshot(chunk)
+
+        for choice in chunk.choices:
+            try:
+                choice_snapshot = completion_snapshot.choices[choice.index]
+                previous_tool_calls = choice_snapshot.message.tool_calls or []
+
+                choice_snapshot.message = cast(
+                    ParsedChatCompletionMessageSnapshot,
+                    construct_type(
+                        type_=ParsedChatCompletionMessageSnapshot,
+                        value=accumulate_delta(
+                            cast(
+                                "dict[object, object]",
+                                model_dump(
+                                    choice_snapshot.message,
+                                    # we don't want to serialise / deserialise our custom properties
+                                    # as they won't appear in the delta and we don't want to have to
+                                    # continuosly reparse the content
+                                    exclude=cast(
+                                        # cast required as mypy isn't smart enough to infer `True` here to `Literal[True]`
+                                        IncEx,
+                                        {
+                                            "parsed": True,
+                                            "tool_calls": {
+                                                idx: {"function": {"parsed_arguments": True}}
+                                                for idx, _ in enumerate(choice_snapshot.message.tool_calls or [])
+                                            },
+                                        },
+                                    ),
+                                ),
+                            ),
+                            cast("dict[object, object]", choice.delta.to_dict()),
+                        ),
+                    ),
+                )
+
+                # ensure tools that have already been parsed are added back into the newly
+                # constructed message snapshot
+                for tool_index, prev_tool in enumerate(previous_tool_calls):
+                    new_tool = (choice_snapshot.message.tool_calls or [])[tool_index]
+
+                    if prev_tool.type == "function":
+                        assert new_tool.type == "function"
+                        new_tool.function.parsed_arguments = prev_tool.function.parsed_arguments
+                    elif TYPE_CHECKING:  # type: ignore[unreachable]
+                        assert_never(prev_tool)
+            except IndexError:
+                choice_snapshot = cast(
+                    ParsedChoiceSnapshot,
+                    construct_type(
+                        type_=ParsedChoiceSnapshot,
+                        value={
+                            **choice.model_dump(exclude_unset=True, exclude={"delta"}),
+                            "message": choice.delta.to_dict(),
+                        },
+                    ),
+                )
+                completion_snapshot.choices.append(choice_snapshot)
+
+            if choice.finish_reason:
+                choice_snapshot.finish_reason = choice.finish_reason
+
+                if has_parseable_input(response_format=self._response_format, input_tools=self._input_tools):
+                    if choice.finish_reason == "length":
+                        # at the time of writing, `.usage` will always be `None` but
+                        # we include it here in case that is changed in the future
+                        raise LengthFinishReasonError(completion=completion_snapshot)
+
+                    if choice.finish_reason == "content_filter":
+                        raise ContentFilterFinishReasonError()
+
+            if (
+                choice_snapshot.message.content
+                and not choice_snapshot.message.refusal
+                and is_given(self._rich_response_format)
+                # partial parsing fails on white-space
+                and choice_snapshot.message.content.lstrip()
+            ):
+                choice_snapshot.message.parsed = from_json(
+                    bytes(choice_snapshot.message.content, "utf-8"),
+                    partial_mode=True,
+                )
+
+            for tool_call_chunk in choice.delta.tool_calls or []:
+                tool_call_snapshot = (choice_snapshot.message.tool_calls or [])[tool_call_chunk.index]
+
+                if tool_call_snapshot.type == "function":
+                    input_tool = get_input_tool_by_name(
+                        input_tools=self._input_tools, name=tool_call_snapshot.function.name
+                    )
+
+                    if (
+                        input_tool
+                        and input_tool.get("function", {}).get("strict")
+                        and tool_call_snapshot.function.arguments
+                    ):
+                        tool_call_snapshot.function.parsed_arguments = from_json(
+                            bytes(tool_call_snapshot.function.arguments, "utf-8"),
+                            partial_mode=True,
+                        )
+                elif TYPE_CHECKING:  # type: ignore[unreachable]
+                    assert_never(tool_call_snapshot)
+
+            if choice.logprobs is not None:
+                if choice_snapshot.logprobs is None:
+                    choice_snapshot.logprobs = build(
+                        ChoiceLogprobs,
+                        content=choice.logprobs.content,
+                        refusal=choice.logprobs.refusal,
+                    )
+                else:
+                    if choice.logprobs.content:
+                        if choice_snapshot.logprobs.content is None:
+                            choice_snapshot.logprobs.content = []
+
+                        choice_snapshot.logprobs.content.extend(choice.logprobs.content)
+
+                    if choice.logprobs.refusal:
+                        if choice_snapshot.logprobs.refusal is None:
+                            choice_snapshot.logprobs.refusal = []
+
+                        choice_snapshot.logprobs.refusal.extend(choice.logprobs.refusal)
+
+        completion_snapshot.usage = chunk.usage
+        completion_snapshot.system_fingerprint = chunk.system_fingerprint
+
+        return completion_snapshot
+
+    def _build_events(
+        self,
+        *,
+        chunk: StreamChunk,
+        completion_snapshot: ParsedChatCompletionSnapshot,
+    ) -> list[ChatCompletionStreamEvent[ResponseFormatT]]:
+        events_to_fire: list[ChatCompletionStreamEvent[ResponseFormatT]] = []
+
+        events_to_fire.append(
+            build(ChunkEvent, type="chunk", chunk=chunk, snapshot=completion_snapshot),
+        )
+
+        for choice in chunk.choices:
+            choice_state = self._get_choice_state(choice)
+            choice_snapshot = completion_snapshot.choices[choice.index]
+
+            if choice.delta.content is not None and choice_snapshot.message.content is not None:
+                events_to_fire.append(
+                    build(
+                        ContentDeltaEvent,
+                        type="content.delta",
+                        delta=choice.delta.content,
+                        snapshot=choice_snapshot.message.content,
+                        parsed=choice_snapshot.message.parsed,
+                    )
+                )
+
+            if choice.delta.refusal is not None and choice_snapshot.message.refusal is not None:
+                events_to_fire.append(
+                    build(
+                        RefusalDeltaEvent,
+                        type="refusal.delta",
+                        delta=choice.delta.refusal,
+                        snapshot=choice_snapshot.message.refusal,
+                    )
+                )
+
+            if choice.delta.tool_calls:
+                tool_calls = choice_snapshot.message.tool_calls
+                assert tool_calls is not None
+
+                for tool_call_delta in choice.delta.tool_calls:
+                    tool_call = tool_calls[tool_call_delta.index]
+
+                    if tool_call.type == "function":
+                        assert tool_call_delta.function is not None
+                        events_to_fire.append(
+                            build(
+                                FunctionToolCallArgumentsDeltaEvent,
+                                type="tool_calls.function.arguments.delta",
+                                name=tool_call.function.name,
+                                index=tool_call_delta.index,
+                                arguments=tool_call.function.arguments,
+                                parsed_arguments=tool_call.function.parsed_arguments,
+                                arguments_delta=tool_call_delta.function.arguments or "",
+                            )
+                        )
+                    elif TYPE_CHECKING:  # type: ignore[unreachable]
+                        assert_never(tool_call)
+
+            if choice.logprobs is not None and choice_snapshot.logprobs is not None:
+                if choice.logprobs.content and choice_snapshot.logprobs.content:
+                    events_to_fire.append(
+                        build(
+                            LogprobsContentDeltaEvent,
+                            type="logprobs.content.delta",
+                            content=choice.logprobs.content,
+                            snapshot=choice_snapshot.logprobs.content,
+                        ),
+                    )
+
+                if choice.logprobs.refusal and choice_snapshot.logprobs.refusal:
+                    events_to_fire.append(
+                        build(
+                            LogprobsRefusalDeltaEvent,
+                            type="logprobs.refusal.delta",
+                            refusal=choice.logprobs.refusal,
+                            snapshot=choice_snapshot.logprobs.refusal,
+                        ),
+                    )
+
+            events_to_fire.extend(
+                choice_state.get_done_events(
+                    choice_chunk=choice,
+                    choice_snapshot=choice_snapshot,
+                    response_format=self._response_format,
+                )
+            )
+
+        return events_to_fire
+
+
+class ChoiceEventState:
+    def __init__(self, *, input_tools: list[InputTool]) -> None:
+        self._input_tools = input_tools
+
+        self._content_done = False
+        self._refusal_done = False
+        self._logprobs_content_done = False
+        self._logprobs_refusal_done = False
+        self._done_tool_calls: set[int] = set()
+        self.__current_tool_call_index: int | None = None
+
+    def get_done_events(
+        self,
+        *,
+        choice_chunk: ChoiceChunk,
+        choice_snapshot: ParsedChoiceSnapshot,
+        response_format: type[ResponseFormatT] | ResponseFormatParam | Omit,
+    ) -> list[ChatCompletionStreamEvent[ResponseFormatT]]:
+        events_to_fire: list[ChatCompletionStreamEvent[ResponseFormatT]] = []
+
+        if choice_snapshot.finish_reason:
+            events_to_fire.extend(
+                self._content_done_events(choice_snapshot=choice_snapshot, response_format=response_format)
+            )
+
+            if (
+                self.__current_tool_call_index is not None
+                and self.__current_tool_call_index not in self._done_tool_calls
+            ):
+                self._add_tool_done_event(
+                    events_to_fire=events_to_fire,
+                    choice_snapshot=choice_snapshot,
+                    tool_index=self.__current_tool_call_index,
+                )
+
+        for tool_call in choice_chunk.delta.tool_calls or []:
+            if self.__current_tool_call_index != tool_call.index:
+                events_to_fire.extend(
+                    self._content_done_events(choice_snapshot=choice_snapshot, response_format=response_format)
+                )
+
+                if self.__current_tool_call_index is not None:
+                    self._add_tool_done_event(
+                        events_to_fire=events_to_fire,
+                        choice_snapshot=choice_snapshot,
+                        tool_index=self.__current_tool_call_index,
+                    )
+
+            self.__current_tool_call_index = tool_call.index
+
+        return events_to_fire
+
+    def _content_done_events(
+        self,
+        *,
+        choice_snapshot: ParsedChoiceSnapshot,
+        response_format: type[ResponseFormatT] | ResponseFormatParam | Omit,
+    ) -> list[ChatCompletionStreamEvent[ResponseFormatT]]:
+        events_to_fire: list[ChatCompletionStreamEvent[ResponseFormatT]] = []
+
+        if choice_snapshot.message.content and not self._content_done:
+            self._content_done = True
+
+            parsed = maybe_parse_content(
+                response_format=response_format,
+                message=choice_snapshot.message,
+            )
+
+            # update the parsed content to now use the richer `response_format`
+            # as opposed to the raw JSON-parsed object as the content is now
+            # complete and can be fully validated.
+            choice_snapshot.message.parsed = parsed
+
+            events_to_fire.append(
+                build(
+                    # we do this dance so that when the `ContentDoneEvent` instance
+                    # is printed at runtime the class name will include the solved
+                    # type variable, e.g. `ContentDoneEvent[MyModelType]`
+                    cast(  # pyright: ignore[reportUnnecessaryCast]
+                        "type[ContentDoneEvent[ResponseFormatT]]",
+                        cast(Any, ContentDoneEvent)[solve_response_format_t(response_format)],
+                    ),
+                    type="content.done",
+                    content=choice_snapshot.message.content,
+                    parsed=parsed,
+                ),
+            )
+
+        if choice_snapshot.message.refusal is not None and not self._refusal_done:
+            self._refusal_done = True
+            events_to_fire.append(
+                build(RefusalDoneEvent, type="refusal.done", refusal=choice_snapshot.message.refusal),
+            )
+
+        if (
+            choice_snapshot.logprobs is not None
+            and choice_snapshot.logprobs.content is not None
+            and not self._logprobs_content_done
+        ):
+            self._logprobs_content_done = True
+            events_to_fire.append(
+                build(LogprobsContentDoneEvent, type="logprobs.content.done", content=choice_snapshot.logprobs.content),
+            )
+
+        if (
+            choice_snapshot.logprobs is not None
+            and choice_snapshot.logprobs.refusal is not None
+            and not self._logprobs_refusal_done
+        ):
+            self._logprobs_refusal_done = True
+            events_to_fire.append(
+                build(LogprobsRefusalDoneEvent, type="logprobs.refusal.done", refusal=choice_snapshot.logprobs.refusal),
+            )
+
+        return events_to_fire
+
+    def _add_tool_done_event(
+        self,
+        *,
+        events_to_fire: list[ChatCompletionStreamEvent[ResponseFormatT]],
+        choice_snapshot: ParsedChoiceSnapshot,
+        tool_index: int,
+    ) -> None:
+        if tool_index in self._done_tool_calls:
+            return
+
+        self._done_tool_calls.add(tool_index)
+
+        assert choice_snapshot.message.tool_calls is not None
+        tool_call_snapshot = choice_snapshot.message.tool_calls[tool_index]
+
+        if tool_call_snapshot.type == "function":
+            parsed_arguments = parse_function_tool_arguments(
+                input_tools=self._input_tools, function=tool_call_snapshot.function
+            )
+
+            # update the parsed content to potentially use a richer type
+            # as opposed to the raw JSON-parsed object as the content is now
+            # complete and can be fully validated.
+            tool_call_snapshot.function.parsed_arguments = parsed_arguments
+
+            events_to_fire.append(
+                build(
+                    FunctionToolCallArgumentsDoneEvent,
+                    type="tool_calls.function.arguments.done",
+                    index=tool_index,
+                    name=tool_call_snapshot.function.name,
+                    arguments=tool_call_snapshot.function.arguments,
+                    parsed_arguments=parsed_arguments,
+                )
+            )
+        elif TYPE_CHECKING:  # type: ignore[unreachable]
+            assert_never(tool_call_snapshot)
+
+
+def _convert_initial_chunk_into_snapshot(chunk: StreamChunk) -> ParsedChatCompletionSnapshot:
+    data = chunk.to_dict()
+    choices = cast("list[object]", data["choices"])
+
+    for choice in chunk.choices:
+        choices[choice.index] = {
+            **choice.model_dump(exclude_unset=True, exclude={"delta"}),
+            "message": choice.delta.to_dict(),
+        }
+
+    return cast(
+        ParsedChatCompletionSnapshot,
+        construct_type(
+            type_=ParsedChatCompletionSnapshot,
+            value={
+                "system_fingerprint": None,
+                **data,
+                "object": "chat.completion",
+            },
+        ),
+    )
+
+
+def _is_valid_stream_chunk(sse_event: StreamChunk) -> bool:
+    # Some providers occasionally send control messages that do not conform to the
+    # standard chunk schema. Filtering on the object type shields downstream logic.
+    return sse_event.object == "chat.completion.chunk"  # type: ignore[attr-defined]

--- a/src/dedalus_labs/lib/streaming/chat/_events.py
+++ b/src/dedalus_labs/lib/streaming/chat/_events.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from typing import Generic, List, Optional, Union
+from typing_extensions import Literal
+
+from ._types import ParsedChatCompletionSnapshot
+from ...._models import BaseModel, GenericModel
+from ..._parsing import ResponseFormatT
+from ....types.chat.stream_chunk import StreamChunk
+from ....types.chat.chat_completion_token_logprob import ChatCompletionTokenLogprob
+
+
+class ChunkEvent(BaseModel):
+    type: Literal["chunk"]
+    chunk: StreamChunk
+    snapshot: ParsedChatCompletionSnapshot
+
+
+class ContentDeltaEvent(BaseModel):
+    type: Literal["content.delta"]
+    delta: str
+    snapshot: str
+    parsed: Optional[object] = None
+
+
+class ContentDoneEvent(GenericModel, Generic[ResponseFormatT]):
+    type: Literal["content.done"]
+    content: str
+    parsed: Optional[ResponseFormatT] = None
+
+
+class RefusalDeltaEvent(BaseModel):
+    type: Literal["refusal.delta"]
+    delta: str
+    snapshot: str
+
+
+class RefusalDoneEvent(BaseModel):
+    type: Literal["refusal.done"]
+    refusal: str
+
+
+class FunctionToolCallArgumentsDeltaEvent(BaseModel):
+    type: Literal["tool_calls.function.arguments.delta"]
+    name: str
+    index: int
+    arguments: str
+    parsed_arguments: object
+    arguments_delta: str
+
+
+class FunctionToolCallArgumentsDoneEvent(BaseModel):
+    type: Literal["tool_calls.function.arguments.done"]
+    name: str
+    index: int
+    arguments: str
+    parsed_arguments: object
+
+
+class LogprobsContentDeltaEvent(BaseModel):
+    type: Literal["logprobs.content.delta"]
+    content: List[ChatCompletionTokenLogprob]
+    snapshot: List[ChatCompletionTokenLogprob]
+
+
+class LogprobsContentDoneEvent(BaseModel):
+    type: Literal["logprobs.content.done"]
+    content: List[ChatCompletionTokenLogprob]
+
+
+class LogprobsRefusalDeltaEvent(BaseModel):
+    type: Literal["logprobs.refusal.delta"]
+    refusal: List[ChatCompletionTokenLogprob]
+    snapshot: List[ChatCompletionTokenLogprob]
+
+
+class LogprobsRefusalDoneEvent(BaseModel):
+    type: Literal["logprobs.refusal.done"]
+    refusal: List[ChatCompletionTokenLogprob]
+
+
+ChatCompletionStreamEvent = Union[
+    ChunkEvent,
+    ContentDeltaEvent,
+    ContentDoneEvent[ResponseFormatT],
+    RefusalDeltaEvent,
+    RefusalDoneEvent,
+    FunctionToolCallArgumentsDeltaEvent,
+    FunctionToolCallArgumentsDoneEvent,
+    LogprobsContentDeltaEvent,
+    LogprobsContentDoneEvent,
+    LogprobsRefusalDeltaEvent,
+    LogprobsRefusalDoneEvent,
+]
+
+
+__all__ = [
+    "ChatCompletionStreamEvent",
+    "ChunkEvent",
+    "ContentDeltaEvent",
+    "ContentDoneEvent",
+    "FunctionToolCallArgumentsDeltaEvent",
+    "FunctionToolCallArgumentsDoneEvent",
+    "LogprobsContentDeltaEvent",
+    "LogprobsContentDoneEvent",
+    "LogprobsRefusalDeltaEvent",
+    "LogprobsRefusalDoneEvent",
+    "RefusalDeltaEvent",
+    "RefusalDoneEvent",
+]

--- a/src/dedalus_labs/lib/streaming/chat/_types.py
+++ b/src/dedalus_labs/lib/streaming/chat/_types.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing_extensions import TypeAlias
+
+from ....types.chat.parsed_chat_completion import (
+    ParsedChoice,
+    ParsedChatCompletion,
+    ParsedChatCompletionMessage,
+)
+
+ParsedChatCompletionSnapshot: TypeAlias = ParsedChatCompletion[object]
+ParsedChatCompletionMessageSnapshot: TypeAlias = ParsedChatCompletionMessage[object]
+ParsedChoiceSnapshot: TypeAlias = ParsedChoice[object]
+
+__all__ = [
+    "ParsedChoiceSnapshot",
+    "ParsedChatCompletionMessageSnapshot",
+    "ParsedChatCompletionSnapshot",
+]

--- a/src/dedalus_labs/lib/utils/__init__.py
+++ b/src/dedalus_labs/lib/utils/__init__.py
@@ -9,7 +9,7 @@
 from __future__ import annotations
 
 from ._schemas import to_schema
-from .stream import stream_async, stream_sync
+from ._stream import stream_async, stream_sync
 
 __all__ = [
     "stream_async",

--- a/src/dedalus_labs/resources/chat/completions.py
+++ b/src/dedalus_labs/resources/chat/completions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import partial
 from typing import Dict, Union, Iterable, Optional
 from typing_extensions import Literal, overload
 
@@ -27,6 +28,10 @@ from ...lib._parsing import (
     parse_chat_completion as _parse_chat_completion,
     type_to_response_format_param as _type_to_response_format,
     validate_input_tools as _validate_input_tools,
+)
+from ...lib.streaming.chat import (
+    ChatCompletionStreamManager,
+    AsyncChatCompletionStreamManager,
 )
 
 __all__ = ["CompletionsResource", "AsyncCompletionsResource"]
@@ -1094,6 +1099,17 @@ class CompletionsResource(SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
         idempotency_key: str | None = None,
     ) -> Completion | Stream[StreamChunk]:
+        import inspect
+        import pydantic
+        from ..._utils import is_given
+
+        # Validate response_format is not a Pydantic model
+        if is_given(response_format) and inspect.isclass(response_format) and issubclass(response_format, pydantic.BaseModel):
+            raise TypeError(
+                "You tried to pass a `BaseModel` class to `chat.completions.create()`; "
+                "You must use `chat.completions.parse()` instead"
+            )
+
         return self._post(
             "/v1/chat/completions",
             body=maybe_transform(
@@ -1170,9 +1186,11 @@ class CompletionsResource(SyncAPIResource):
     def parse(
         self,
         *,
-        messages: Union[Iterable[Dict[str, object]], str],
         model: completion_create_params.Model,
         response_format: type[ResponseFormatT] | Omit = omit,
+        messages: Union[Iterable[Dict[str, object]], str, None] | Omit = omit,
+        input: Union[Iterable[Dict[str, object]], str, None] | Omit = omit,
+        instructions: Union[str, Iterable[Dict[str, object]], None] | Omit = omit,
         agent_attributes: Optional[Dict[str, float]] | Omit = omit,
         audio: Optional[Dict[str, object]] | Omit = omit,
         auto_execute_tools: bool | Omit = omit,
@@ -1184,8 +1202,6 @@ class CompletionsResource(SyncAPIResource):
         generation_config: Optional[Dict[str, object]] | Omit = omit,
         guardrails: Optional[Iterable[Dict[str, object]]] | Omit = omit,
         handoff_config: Optional[Dict[str, object]] | Omit = omit,
-        input: Union[Iterable[Dict[str, object]], str, None] | Omit = omit,
-        instructions: Union[str, Iterable[Dict[str, object]], None] | Omit = omit,
         logit_bias: Optional[Dict[str, int]] | Omit = omit,
         logprobs: Optional[bool] | Omit = omit,
         max_completion_tokens: Optional[int] | Omit = omit,
@@ -1332,6 +1348,141 @@ class CompletionsResource(SyncAPIResource):
                 post_parser=parser,
             ),
             cast_to=ParsedChatCompletion,
+        )
+
+    def stream(
+        self,
+        *,
+        model: completion_create_params.Model,
+        messages: Union[Iterable[Dict[str, object]], str, None] | Omit = omit,
+        response_format: type[ResponseFormatT] | Omit = omit,
+        agent_attributes: Optional[Dict[str, float]] | Omit = omit,
+        audio: Optional[Dict[str, object]] | Omit = omit,
+        auto_execute_tools: bool | Omit = omit,
+        deferred: Optional[bool] | Omit = omit,
+        disable_automatic_function_calling: Optional[bool] | Omit = omit,
+        frequency_penalty: Optional[float] | Omit = omit,
+        function_call: Union[str, Dict[str, object], None] | Omit = omit,
+        functions: Optional[Iterable[Dict[str, object]]] | Omit = omit,
+        generation_config: Optional[Dict[str, object]] | Omit = omit,
+        guardrails: Optional[Iterable[Dict[str, object]]] | Omit = omit,
+        handoff_config: Optional[Dict[str, object]] | Omit = omit,
+        input: Union[Iterable[Dict[str, object]], str, None] | Omit = omit,
+        instructions: Union[str, Iterable[Dict[str, object]], None] | Omit = omit,
+        logit_bias: Optional[Dict[str, int]] | Omit = omit,
+        logprobs: Optional[bool] | Omit = omit,
+        max_completion_tokens: Optional[int] | Omit = omit,
+        max_tokens: Optional[int] | Omit = omit,
+        max_turns: Optional[int] | Omit = omit,
+        mcp_servers: Union[str, SequenceNotStr[str], None] | Omit = omit,
+        metadata: Optional[Dict[str, str]] | Omit = omit,
+        modalities: Optional[SequenceNotStr[str]] | Omit = omit,
+        model_attributes: Optional[Dict[str, Dict[str, float]]] | Omit = omit,
+        n: Optional[int] | Omit = omit,
+        parallel_tool_calls: Optional[bool] | Omit = omit,
+        prediction: Optional[Dict[str, object]] | Omit = omit,
+        presence_penalty: Optional[float] | Omit = omit,
+        prompt_cache_key: Optional[str] | Omit = omit,
+        reasoning_effort: Optional[Literal["low", "medium", "high"]] | Omit = omit,
+        safety_identifier: Optional[str] | Omit = omit,
+        safety_settings: Optional[Iterable[Dict[str, object]]] | Omit = omit,
+        search_parameters: Optional[Dict[str, object]] | Omit = omit,
+        seed: Optional[int] | Omit = omit,
+        service_tier: Optional[Literal["auto", "default"]] | Omit = omit,
+        stop: Optional[SequenceNotStr[str]] | Omit = omit,
+        store: Optional[bool] | Omit = omit,
+        stream_options: Optional[Dict[str, object]] | Omit = omit,
+        system: Union[str, Iterable[Dict[str, object]], None] | Omit = omit,
+        temperature: Optional[float] | Omit = omit,
+        thinking: Optional[completion_create_params.Thinking] | Omit = omit,
+        tool_choice: Union[str, Dict[str, object], None] | Omit = omit,
+        tool_config: Optional[Dict[str, object]] | Omit = omit,
+        tools: Optional[Iterable[Dict[str, object]]] | Omit = omit,
+        top_k: Optional[int] | Omit = omit,
+        top_logprobs: Optional[int] | Omit = omit,
+        top_p: Optional[float] | Omit = omit,
+        user: Optional[str] | Omit = omit,
+        verbosity: Optional[Literal["low", "medium", "high"]] | Omit = omit,
+        web_search_options: Optional[Dict[str, object]] | Omit = omit,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+        idempotency_key: str | None = None,
+    ) -> ChatCompletionStreamManager[ResponseFormatT]:
+        """Stream chat completions with the same structured parsing guarantees as `.parse()`."""
+
+        chat_completion_tools = _validate_input_tools(tools)
+        extra_headers = {
+            "X-Stainless-Helper-Method": "chat.completions.stream",
+            **(extra_headers or {}),
+        }
+
+        api_request = partial(
+            self.create,
+            model=model,
+            messages=messages,
+            agent_attributes=agent_attributes,
+            audio=audio,
+            auto_execute_tools=auto_execute_tools,
+            deferred=deferred,
+            disable_automatic_function_calling=disable_automatic_function_calling,
+            frequency_penalty=frequency_penalty,
+            function_call=function_call,
+            functions=functions,
+            generation_config=generation_config,
+            guardrails=guardrails,
+            handoff_config=handoff_config,
+            input=input,
+            instructions=instructions,
+            logit_bias=logit_bias,
+            logprobs=logprobs,
+            max_completion_tokens=max_completion_tokens,
+            max_tokens=max_tokens,
+            max_turns=max_turns,
+            mcp_servers=mcp_servers,
+            metadata=metadata,
+            modalities=modalities,
+            model_attributes=model_attributes,
+            n=n,
+            parallel_tool_calls=parallel_tool_calls,
+            prediction=prediction,
+            presence_penalty=presence_penalty,
+            prompt_cache_key=prompt_cache_key,
+            reasoning_effort=reasoning_effort,
+            safety_identifier=safety_identifier,
+            safety_settings=safety_settings,
+            search_parameters=search_parameters,
+            seed=seed,
+            service_tier=service_tier,
+            stop=stop,
+            store=store,
+            stream=True,
+            stream_options=stream_options,
+            system=system,
+            temperature=temperature,
+            thinking=thinking,
+            tool_choice=tool_choice,
+            tool_config=tool_config,
+            tools=tools,
+            top_k=top_k,
+            top_logprobs=top_logprobs,
+            top_p=top_p,
+            user=user,
+            verbosity=verbosity,
+            web_search_options=web_search_options,
+            response_format=_type_to_response_format(response_format),
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            extra_body=extra_body,
+            timeout=timeout,
+            idempotency_key=idempotency_key,
+        )
+
+        return ChatCompletionStreamManager(
+            api_request,
+            response_format=response_format,
+            input_tools=chat_completion_tools,
         )
 
 
@@ -2397,6 +2548,17 @@ class AsyncCompletionsResource(AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
         idempotency_key: str | None = None,
     ) -> Completion | AsyncStream[StreamChunk]:
+        import inspect
+        import pydantic
+        from ..._utils import is_given
+
+        # Validate response_format is not a Pydantic model
+        if is_given(response_format) and inspect.isclass(response_format) and issubclass(response_format, pydantic.BaseModel):
+            raise TypeError(
+                "You tried to pass a `BaseModel` class to `chat.completions.create()`; "
+                "You must use `chat.completions.parse()` instead"
+            )
+
         return await self._post(
             "/v1/chat/completions",
             body=await async_maybe_transform(
@@ -2473,9 +2635,11 @@ class AsyncCompletionsResource(AsyncAPIResource):
     async def parse(
         self,
         *,
-        messages: Union[Iterable[Dict[str, object]], str],
         model: completion_create_params.Model,
         response_format: type[ResponseFormatT] | Omit = omit,
+        messages: Union[Iterable[Dict[str, object]], str, None] | Omit = omit,
+        input: Union[Iterable[Dict[str, object]], str, None] | Omit = omit,
+        instructions: Union[str, Iterable[Dict[str, object]], None] | Omit = omit,
         agent_attributes: Optional[Dict[str, float]] | Omit = omit,
         audio: Optional[Dict[str, object]] | Omit = omit,
         auto_execute_tools: bool | Omit = omit,
@@ -2487,8 +2651,6 @@ class AsyncCompletionsResource(AsyncAPIResource):
         generation_config: Optional[Dict[str, object]] | Omit = omit,
         guardrails: Optional[Iterable[Dict[str, object]]] | Omit = omit,
         handoff_config: Optional[Dict[str, object]] | Omit = omit,
-        input: Union[Iterable[Dict[str, object]], str, None] | Omit = omit,
-        instructions: Union[str, Iterable[Dict[str, object]], None] | Omit = omit,
         logit_bias: Optional[Dict[str, int]] | Omit = omit,
         logprobs: Optional[bool] | Omit = omit,
         max_completion_tokens: Optional[int] | Omit = omit,
@@ -2616,6 +2778,140 @@ class AsyncCompletionsResource(AsyncAPIResource):
                 post_parser=parser,
             ),
             cast_to=ParsedChatCompletion,
+        )
+
+    def stream(
+        self,
+        *,
+        model: completion_create_params.Model,
+        messages: Union[Iterable[Dict[str, object]], str, None] | Omit = omit,
+        response_format: type[ResponseFormatT] | Omit = omit,
+        agent_attributes: Optional[Dict[str, float]] | Omit = omit,
+        audio: Optional[Dict[str, object]] | Omit = omit,
+        auto_execute_tools: bool | Omit = omit,
+        deferred: Optional[bool] | Omit = omit,
+        disable_automatic_function_calling: Optional[bool] | Omit = omit,
+        frequency_penalty: Optional[float] | Omit = omit,
+        function_call: Union[str, Dict[str, object], None] | Omit = omit,
+        functions: Optional[Iterable[Dict[str, object]]] | Omit = omit,
+        generation_config: Optional[Dict[str, object]] | Omit = omit,
+        guardrails: Optional[Iterable[Dict[str, object]]] | Omit = omit,
+        handoff_config: Optional[Dict[str, object]] | Omit = omit,
+        input: Union[Iterable[Dict[str, object]], str, None] | Omit = omit,
+        instructions: Union[str, Iterable[Dict[str, object]], None] | Omit = omit,
+        logit_bias: Optional[Dict[str, int]] | Omit = omit,
+        logprobs: Optional[bool] | Omit = omit,
+        max_completion_tokens: Optional[int] | Omit = omit,
+        max_tokens: Optional[int] | Omit = omit,
+        max_turns: Optional[int] | Omit = omit,
+        mcp_servers: Union[str, SequenceNotStr[str], None] | Omit = omit,
+        metadata: Optional[Dict[str, str]] | Omit = omit,
+        modalities: Optional[SequenceNotStr[str]] | Omit = omit,
+        model_attributes: Optional[Dict[str, Dict[str, float]]] | Omit = omit,
+        n: Optional[int] | Omit = omit,
+        parallel_tool_calls: Optional[bool] | Omit = omit,
+        prediction: Optional[Dict[str, object]] | Omit = omit,
+        presence_penalty: Optional[float] | Omit = omit,
+        prompt_cache_key: Optional[str] | Omit = omit,
+        reasoning_effort: Optional[Literal["low", "medium", "high"]] | Omit = omit,
+        safety_identifier: Optional[str] | Omit = omit,
+        safety_settings: Optional[Iterable[Dict[str, object]]] | Omit = omit,
+        search_parameters: Optional[Dict[str, object]] | Omit = omit,
+        seed: Optional[int] | Omit = omit,
+        service_tier: Optional[Literal["auto", "default"]] | Omit = omit,
+        stop: Optional[SequenceNotStr[str]] | Omit = omit,
+        store: Optional[bool] | Omit = omit,
+        stream_options: Optional[Dict[str, object]] | Omit = omit,
+        system: Union[str, Iterable[Dict[str, object]], None] | Omit = omit,
+        temperature: Optional[float] | Omit = omit,
+        thinking: Optional[completion_create_params.Thinking] | Omit = omit,
+        tool_choice: Union[str, Dict[str, object], None] | Omit = omit,
+        tool_config: Optional[Dict[str, object]] | Omit = omit,
+        tools: Optional[Iterable[Dict[str, object]]] | Omit = omit,
+        top_k: Optional[int] | Omit = omit,
+        top_logprobs: Optional[int] | Omit = omit,
+        top_p: Optional[float] | Omit = omit,
+        user: Optional[str] | Omit = omit,
+        verbosity: Optional[Literal["low", "medium", "high"]] | Omit = omit,
+        web_search_options: Optional[Dict[str, object]] | Omit = omit,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+        idempotency_key: str | None = None,
+    ) -> AsyncChatCompletionStreamManager[ResponseFormatT]:
+        """Async variant of `stream()` with identical semantics."""
+
+        chat_completion_tools = _validate_input_tools(tools)
+        extra_headers = {
+            "X-Stainless-Helper-Method": "chat.completions.stream",
+            **(extra_headers or {}),
+        }
+
+        api_request = self.create(
+            model=model,
+            messages=messages,
+            agent_attributes=agent_attributes,
+            audio=audio,
+            auto_execute_tools=auto_execute_tools,
+            deferred=deferred,
+            disable_automatic_function_calling=disable_automatic_function_calling,
+            frequency_penalty=frequency_penalty,
+            function_call=function_call,
+            functions=functions,
+            generation_config=generation_config,
+            guardrails=guardrails,
+            handoff_config=handoff_config,
+            input=input,
+            instructions=instructions,
+            logit_bias=logit_bias,
+            logprobs=logprobs,
+            max_completion_tokens=max_completion_tokens,
+            max_tokens=max_tokens,
+            max_turns=max_turns,
+            mcp_servers=mcp_servers,
+            metadata=metadata,
+            modalities=modalities,
+            model_attributes=model_attributes,
+            n=n,
+            parallel_tool_calls=parallel_tool_calls,
+            prediction=prediction,
+            presence_penalty=presence_penalty,
+            prompt_cache_key=prompt_cache_key,
+            reasoning_effort=reasoning_effort,
+            safety_identifier=safety_identifier,
+            safety_settings=safety_settings,
+            search_parameters=search_parameters,
+            seed=seed,
+            service_tier=service_tier,
+            stop=stop,
+            store=store,
+            stream=True,
+            stream_options=stream_options,
+            system=system,
+            temperature=temperature,
+            thinking=thinking,
+            tool_choice=tool_choice,
+            tool_config=tool_config,
+            tools=tools,
+            top_k=top_k,
+            top_logprobs=top_logprobs,
+            top_p=top_p,
+            user=user,
+            verbosity=verbosity,
+            web_search_options=web_search_options,
+            response_format=_type_to_response_format(response_format),
+            extra_headers=extra_headers,
+            extra_query=extra_query,
+            extra_body=extra_body,
+            timeout=timeout,
+            idempotency_key=idempotency_key,
+        )
+
+        return AsyncChatCompletionStreamManager(
+            api_request,
+            response_format=response_format,
+            input_tools=chat_completion_tools,
         )
 
 

--- a/src/dedalus_labs/utils/stream.py
+++ b/src/dedalus_labs/utils/stream.py
@@ -6,6 +6,6 @@
 
 """Stream utilities for printing model responses in real-time."""
 
-from ..lib.utils.stream import stream_async, stream_sync
+from ..lib.utils._stream import stream_async, stream_sync
 
 __all__ = ["stream_async", "stream_sync"]

--- a/tests/test__bug_report.py
+++ b/tests/test__bug_report.py
@@ -1,0 +1,194 @@
+# ==============================================================================
+#                  © 2025 Dedalus Labs, Inc. and affiliates
+#                            Licensed under MIT
+#           github.com/dedalus-labs/dedalus-sdk-python/LICENSE
+# ==============================================================================
+
+"""Tests for SDK bug report URL generation."""
+
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+
+from dedalus_labs._exceptions import APIError, APIStatusError, BadRequestError
+from dedalus_labs.lib._bug_report import generate_bug_report_url, get_bug_report_url_from_error
+
+
+class TestGenerateBugReportUrl:
+    """Tests for generate_bug_report_url function."""
+
+    def test_minimal_parameters(self):
+        """URL generation with no params includes auto-populated system info."""
+        url = generate_bug_report_url()
+
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        assert parsed.netloc == "github.com"
+        assert parsed.path == "/dedalus-labs/api/issues/new"
+        assert params["template"] == ["bug-report.yml"]
+        assert params["component"] == ["Python SDK"]
+        assert "python_version" in params
+        assert "platform" in params
+
+    def test_all_parameters(self):
+        """URL generation with all parameters populates fields correctly."""
+        url = generate_bug_report_url(
+            version="0.0.1",
+            error_type="APIError",
+            error_message="Connection timeout",
+            session_id="test-session-123",
+            environment="dev",
+        )
+
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        assert params["version"] == ["0.0.1"]
+        assert params["error_type"] == ["APIError"]
+        assert params["actual"] == ["Connection timeout"]
+        assert params["session_id"] == ["Session ID: test-session-123"]
+        assert params["environment"] == ["dev"]
+        assert params["steps"][0].startswith("Uploaded thread: test-session-123")
+
+    def test_session_id_prefilling(self):
+        """Session ID pre-fills both session_id and steps fields."""
+        url = generate_bug_report_url(session_id="abc-123")
+
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        assert params["session_id"] == ["Session ID: abc-123"]
+        assert "abc-123" in params["steps"][0]
+
+    def test_custom_template(self):
+        """Custom template name is respected."""
+        url = generate_bug_report_url(template="custom.yml")
+
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        assert params["template"] == ["custom.yml"]
+
+
+class TestGetBugReportUrlFromError:
+    """Tests for get_bug_report_url_from_error function."""
+
+    def test_basic_api_error(self):
+        """Generates URL from basic APIError instance."""
+        request = httpx.Request("POST", "https://api.dedalus.ai/v1/chat/completions")
+        error = APIError("Request failed", request, body=None)
+
+        url = get_bug_report_url_from_error(error)
+
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        assert params["error_type"] == ["APIError"]
+        assert params["actual"] == ["Request failed"]
+        assert "version" in params
+
+    def test_api_status_error_with_code(self):
+        """Status code is included in error message for APIStatusError."""
+        request = httpx.Request("POST", "https://api.dedalus.ai/v1/chat/completions")
+        response = httpx.Response(400, request=request)
+        error = BadRequestError("Invalid request", response=response, body=None)
+
+        url = get_bug_report_url_from_error(error)
+
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        assert params["error_type"] == ["BadRequestError"]
+        assert "[400]" in params["actual"][0]
+        assert "Invalid request" in params["actual"][0]
+
+    def test_with_session_id(self):
+        """Session ID parameter is included when provided."""
+        request = httpx.Request("POST", "https://api.dedalus.ai/v1/chat/completions")
+        error = APIError("Test error", request, body=None)
+
+        url = get_bug_report_url_from_error(error, session_id="session-456")
+
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        assert params["session_id"] == ["Session ID: session-456"]
+        assert "session-456" in params["steps"][0]
+
+    def test_includes_sdk_version(self):
+        """SDK version is automatically included from __version__."""
+        request = httpx.Request("POST", "https://api.dedalus.ai/v1/chat/completions")
+        error = APIError("Test error", request, body=None)
+
+        url = get_bug_report_url_from_error(error)
+
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        # Should have version parameter populated
+        assert "version" in params
+        # Should be non-empty
+        assert len(params["version"][0]) > 0
+
+
+class TestPlatformInfo:
+    """Tests for platform info collection."""
+
+    def test_platform_info_format(self):
+        """Platform info has expected format."""
+        url = generate_bug_report_url()
+
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+        platform_info = params["platform"][0]
+
+        # Format: "System Release Machine"
+        parts = platform_info.split()
+        assert len(parts) >= 2
+
+    def test_python_version_format(self):
+        """Python version has expected format."""
+        url = generate_bug_report_url()
+
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+        python_version = params["python_version"][0]
+
+        assert python_version.startswith("Python ")
+        version_part = python_version.replace("Python ", "")
+        assert len(version_part) > 0
+        assert version_part[0].isdigit()
+
+
+class TestUrlEncoding:
+    """Tests for URL encoding edge cases."""
+
+    def test_special_chars_encoded(self):
+        """Special characters are properly URL-encoded."""
+        url = generate_bug_report_url(
+            error_message="Error @ 127.0.0.1:8080 #fail",
+            session_id="test/session#123",
+        )
+
+        # URL query string should not contain raw special chars
+        query_string = url.split("?")[1]
+        assert "@" not in query_string
+        assert "#" not in query_string
+
+        # But decoded params should contain them
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+        assert "@" in params["actual"][0]
+
+    def test_unicode_handling(self):
+        """Unicode characters are properly encoded."""
+        url = generate_bug_report_url(error_message="Error: 数据库连接失败")
+
+        # Should not raise and should produce valid URL
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+        assert "数据库连接失败" in params["actual"][0]


### PR DESCRIPTION
Add event manager, helpers, and types to support streamable structured outputs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds structured streaming for chat completions (event/state managers), expands parsing utilities, introduces bug-report URL helper + template, and updates utils, compat, and deps.
> 
> - **Chat Completions API**:
>   - **Streaming**: New `chat.completions.stream()` (sync/async) returning `ChatCompletionStreamManager[...]` with structured parsing; `create()` now rejects Pydantic models for `response_format` (use `parse()`).
>   - **Parsing**: New `parse()` (sync/async) that auto-parses content and tool calls into typed models.
> - **Streaming Framework**:
>   - Add `lib/streaming` with `ChatCompletionStream`, `AsyncChatCompletionStream`, managers, `ChatCompletionStreamState`, delta accumulator, and rich event types (`content.delta/done`, tool args delta/done, logprobs, etc.).
>   - `utils.stream_{sync,async}` now handle both raw chunk iterators and event managers.
> - **Parsing Lib Enhancements**:
>   - New helpers: `maybe_parse_content`, `parse_function_tool_arguments`, `get_input_tool_by_name`, `has_parseable_input`, `solve_response_format_t`; stricter tool validation; improved `type_to_response_format_param`.
> - **Bug Reporting**:
>   - New `lib._bug_report` with `generate_bug_report_url` and `get_bug_report_url_from_error`; exported in `__init__`.
>   - Add GitHub issue template `.github/ISSUE_TEMPLATE/bug-report.yml` and tests `tests/test__bug_report.py`.
> - **Compat/Types**:
>   - `model_dump(..., by_alias=True)` and adjusted `model_json_schema` typing.
> - **Dependencies**:
>   - Add `jiter<0.10.0` for partial JSON streaming.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3838ebe4db440a852c233cd2a96c2b7a4f0c4082. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->