### PR TITLE
fix(mcp): correct wire format for URL-based servers

### DIFF
--- a/src/dedalus_labs/lib/mcp/request.py
+++ b/src/dedalus_labs/lib/mcp/request.py
@@ -186,14 +186,10 @@ def _embed_credentials(
 
     for server in servers:
         if isinstance(server, str):
-            # Slug string -> full spec with name = slug
-            result.append(
-                {
-                    "slug": server,
-                    "name": server,
-                    "credentials": creds_dict,
-                }
-            )
+            if server.startswith(("http://", "https://")):
+                result.append({"url": server, "name": server, "credentials": creds_dict})
+            else:
+                result.append({"slug": server, "name": server, "credentials": creds_dict})
         elif isinstance(server, dict):
             # Existing spec -> add name (if missing) and credentials
             name = server.get("name") or server.get("slug") or server.get("url") or ""


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes credential embedding for URL-based MCP servers.
> 
> - In `request.py` `_embed_credentials`, string entries are now classified: URL strings (`http://`/`https://`) serialize as `{"url": ..., "name": ..., "credentials": ...}`; non-URL strings serialize as `{"slug": ..., ...}`
> - Existing dict specs still have `name` normalized and `credentials` added
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e3c2f21bc937ab420c5b1ef93a205295ccbc7b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->